### PR TITLE
Update test runner to use v22.1.0-alpha.5

### DIFF
--- a/build_test_psycopg2.sh
+++ b/build_test_psycopg2.sh
@@ -28,8 +28,12 @@ conn = psycopg2.connect("")
 conn.autocommit = True
 curs = conn.cursor()
 curs.execute("CREATE DATABASE IF NOT EXISTS ${PSYCOPG2_TESTDB}")
+curs.execute("CREATE USER testuser")
+curs.execute("GRANT admin TO testuser")
+curs.execute("ALTER ROLE testuser SET enable_implicit_transaction_for_batch_statements = true")
 HERE
 
+export PGUSER=testuser
 # Run the test suite
 python -c "import tests; tests.unittest.main(defaultTest='${test}')" \
     --verbose

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   cockroachdb:
-    image: "cockroachdb/cockroach:v20.1.3"
+    image: "cockroachdb/cockroach-unstable:v22.1.0-alpha.5"
     command: "start-single-node --insecure"
   psycopg2:
     image: "python:3.8-buster"


### PR DESCRIPTION
This allows more tests to pass. I will update this to use the final
release when it's available.